### PR TITLE
Combat log for player's turn

### DIFF
--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/combat-log/combat-log.component.css
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/combat-log/combat-log.component.css
@@ -10,6 +10,7 @@ div.combat-log-header h1 {
     padding: 2em;
     overflow-y: scroll;
     max-height:400px;
+    min-width: 400px;
 }
 
 .combat-log-content-item {

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-handler.component.html
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-handler.component.html
@@ -1,7 +1,6 @@
 <section>
     <div>
         <app-encounter-setup
-        (reset)="reset()"
         (displayEncounterChanged)="displayEncounterChanged($event)"
         (encounterNameSet)="encounterNameSet($event)">
         </app-encounter-setup>
@@ -18,6 +17,4 @@
         [displayEncounter]="displayEncounter">
         </app-round-handler>
     </div>
-    
-    
 </section>

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-handler.component.ts
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-handler.component.ts
@@ -11,7 +11,6 @@ import { RoundHandlerComponent } from './round-handler/round-handler.component';
   styleUrls: ['./encounter-handler.component.css']
 })
 export class EncounterHandlerComponent {
-
   @ViewChild(RoundHandlerComponent) roundHandlerChild!: any;
   @ViewChild(InitiativeTimelineComponent) initiativeTimelineChild!: any;
 
@@ -19,10 +18,6 @@ export class EncounterHandlerComponent {
   public monsters: IMonster[] = [];
 
   public displayEncounter: boolean = false;
-
-  reset() {
-    this.roundHandlerChild.roundReset();
-  }
 
   displayEncounterChanged(displayEncounter: boolean) {
     this.displayEncounter = displayEncounter;

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-setup/encounter-setup.component.html
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-setup/encounter-setup.component.html
@@ -5,8 +5,8 @@
 <div class="encounter-setup-container">
     <div class="encounter-setup-centered">
         Choose your encounter:
-        <mat-form-field appearance="fill">
-            <mat-label>Select a biome</mat-label>
+        <mat-form-field appearance="fill" id="biome-select">
+            <mat-label for="biome-select">Select a biome</mat-label>
             <mat-select #biomeTypeSelector (selectionChange)="onSelected(biomeTypeSelector.value)">
                 <mat-option *ngFor="let biomeType of biomeTypes" [value]="biomeType">
                     {{biomeType}}

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-setup/encounter-setup.component.ts
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-setup/encounter-setup.component.ts
@@ -14,8 +14,7 @@ export class EncounterSetupComponent {
   constructor(private biomeTypeService: BiomeTypeService,
               private encounterService: EncounterService,
               private encounterHandlerService: EncounterHandlerService) { }
-
-  @Output("reset") reset: EventEmitter<any> = new EventEmitter;
+              
   @Output("displayEncounterChanged") displayEncounterChanged: EventEmitter<boolean> = new EventEmitter; 
   @Output("encounterNameSet") encounterNameSet: EventEmitter<string> = new EventEmitter; 
 

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-setup/encounter-setup.component.ts
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/encounter-setup/encounter-setup.component.ts
@@ -50,6 +50,5 @@ export class EncounterSetupComponent {
 
   async encounterReset(): Promise<void> {
     this.displayEncounterChanged.emit(false);
-    this.reset.emit();
   }  
 }

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/initiative-timeline/initiative-timeline.component.html
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/initiative-timeline/initiative-timeline.component.html
@@ -2,6 +2,8 @@
     <h1>Encounter: {{encounterName}}</h1>
     <div class="card-container">
         <mat-card *ngFor="let monster of monsters">
+        <!-- If the monster is not a player -->
+        <div *ngIf="!monster.player">
             <div class="card-info-and-picture-container">
                 <div class="card-info">
                     <div class="card-info-centered">
@@ -21,7 +23,19 @@
                 <button mat-raised-button class="details-button" color="accent"
                     (click)="showMonsterDetailsModal(monster.generatedMonsterIdentifier)">Details</button>
             </div>
+        </div>
+        <!-- If the monster is a player -->
+        <div *ngIf="monster.player">
+            <div class="card-info-and-picture-container">
+                <div class="card-info">
+                    <div class="card-info-centered">
+                        <div class="mat-body-strong mat-h1"> {{ monster.name }} </div>
+                        <div> Initiative: {{ monster.initiative }} </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         </mat-card>
     </div>
-    <!-- <app-monster-details></app-monster-details> -->
 </div>

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/round-handler/round-handler.component.html
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/round-handler/round-handler.component.html
@@ -7,6 +7,7 @@
         </div>
         <div class="round-handler-current-turn-description" *ngIf="activationReady">
             <div *ngIf="currentMonster">
+            <div *ngIf="!currentMonster.player">
                 <div class="round-handler-current-turn-description-header flex-row flex-space-around">
                     <h2>Combat Round {{currentRound}}</h2>
                     <h2>{{currentMonster.name}} {{currentMonster.generatedMonsterIdentifier}} activation</h2>
@@ -18,6 +19,12 @@
                     <div>Dealing {{attack.damageResult}}, on a hit</div>
                 </div>
                 <div *ngIf="currentMonster.attacks.extraEffect != 'none'">{{currentMonster.attacks.extraEffect}}</div>
+            </div>
+
+            <div *ngIf="currentMonster.player">
+                <h2>Combat Round {{currentRound}}</h2>
+                <h2>{{currentMonster.name}}'s activation</h2>
+            </div>
             </div>
         </div>
         <div class="round-handler-show-log-button">

--- a/5eCombatTrackerUI/src/app/core/modules/encounter-handler/round-handler/round-handler.component.ts
+++ b/5eCombatTrackerUI/src/app/core/modules/encounter-handler/round-handler/round-handler.component.ts
@@ -17,7 +17,7 @@ export class RoundHandlerComponent {
   public currentMonster!: IMonster;
 
   public currentTurn: number = 0;
-  public currentRound: number = 1;
+  public currentRound: number = 0;
 
   @Input() public displayEncounter: boolean = false;
   public activationReady: boolean = false;
@@ -27,6 +27,7 @@ export class RoundHandlerComponent {
               private dialog: MatDialog) {
     this.getMonsters();
     this.getLog();
+    this.roundReset();
   }
 
   getMonsters(): void {

--- a/5eCombatTrackerUI/src/app/core/services/encounter-handler.service.ts
+++ b/5eCombatTrackerUI/src/app/core/services/encounter-handler.service.ts
@@ -24,7 +24,6 @@ export class EncounterHandlerService extends Observables {
     public async setupMonsterData(monsterEncounter: IMonsterEncounter[]): Promise<void> {
         this.resetMonsters();
         for (let i = 0; i < monsterEncounter.length; i++) {
-            console.log(monsterEncounter);
             for (let j = 1; j <= monsterEncounter[i].quantity; j++) {
                 let initiative = await this.dieRoller.rollDie(20, 0, 1);
                 this.generatedId++;
@@ -82,6 +81,11 @@ export class EncounterHandlerService extends Observables {
     }
 
     public async setMonsterAttack(round: number): Promise<void> {
+        if (this._internalMonsters[0].player) {
+            this.writePlayerTurnToLog(this._internalMonsters[0].name, round);
+            return;
+        }
+
         const response = await firstValueFrom(
             this.monsterAttackService.getMonsterAttack(this._internalMonsters[0].id)
         );
@@ -97,9 +101,7 @@ export class EncounterHandlerService extends Observables {
         }
 
         this._internalMonsters[0].attackResult = attackResult;
-        for (let i = 0; i < this._internalMonsters[0].attacks.numberOfAttacks; i++) {
-            this.writeAttackToLog(this._internalMonsters[0], round)
-        }
+        this.writeAttackToLog(this._internalMonsters[0], round)
 
         this.setMonsters();
     }
@@ -110,10 +112,15 @@ export class EncounterHandlerService extends Observables {
                 monsterData.name + " " + monsterData.generatedMonsterIdentifier + " " +
                 "attack " + round + " " +
                 "with " + monsterData.attacks.weaponName + " " +
-                "hitting with a " + monsterData.attackResult[i].toHitResult
-                "for " + monsterData.attackResult[i].damageResult;
-            this.logPush();
-        }
+                "hitting with a " + monsterData.attackResult[i].toHitResult + " " +
+                "for " + monsterData.attackResult[i].damageResult + " damage";
+                this.logPush();
+            }
+    }
+
+    public writePlayerTurnToLog(name: string, round: number) {
+        this._logEntry = name + "'s turn " + round;
+        this.logPush();
     }
 
     private async resetMonsters(): Promise<void> {

--- a/5eCombatTrackerUI/src/app/core/services/observables.ts
+++ b/5eCombatTrackerUI/src/app/core/services/observables.ts
@@ -32,7 +32,7 @@ export abstract class Observables {
       var currentLog: string[] = this._log.getValue();
       currentLog.unshift(this._logEntry)
       this._log.next(currentLog)
-    }   
+    }
     public logReset(): void {
       this._internalLog = [];
       this._log.next(this._internalLog);


### PR DESCRIPTION
additonally, bug fixes surrounding page reset for first load, unable to access child component round reset. Due to the component being behind an *ngIf, stopping it from seeing it on render for the first time.

This wasnt even needed. reset logic moved to constructor for that child component.

